### PR TITLE
ci: add check for package-lock.json version

### DIFF
--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -34,6 +34,10 @@ jobs:
         run: test -e ./package.json && echo "::set-output name=exists::true" || echo "::set-output name=exists::false"
         shell: bash
       - if: steps.packagejson.outputs.exists == 'true'
+        name: Check package-lock.json version is '2'
+        run: |
+          grep '"lockfileVersion": 2' package-lock.json
+      - if: steps.packagejson.outputs.exists == 'true'
         name: Setup Node.js
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
**Description**

This PR adds an extra check in case `package.json` is found that will check the `package-lock.json` version is set to `2`. Otherwise, the action will fail.

This avoids issues like https://github.com/asyncapi/parser-js/pull/650.

**Related issue(s)**
https://github.com/asyncapi/parser-js/pull/650